### PR TITLE
top_k_frequent

### DIFF
--- a/donghyuk/LeetCode/top_k_frequent/qsort.c
+++ b/donghyuk/LeetCode/top_k_frequent/qsort.c
@@ -1,0 +1,49 @@
+#include <stdlib.h>
+
+void	swap(void *a, void *b, size_t size)
+{
+	char	tmp;
+
+	while (size > 0)
+	{
+		tmp = (*(char *)a);
+		*((char *)a++) = (*(char *)b);
+		*((char *)b++) = tmp;
+		size--;
+	}
+}
+
+void quick_sort(void *base, size_t total_elems, size_t size, int (*cmp)(const void* left, const void* right))
+{
+	char	*p_base;
+	char	*left;
+	char	*right;
+	char	*pivot;
+	char	*lo;
+	char	*hi;
+
+	if (total_elems < 1)
+		return ;
+	p_base = (char *)base;
+	lo = p_base;
+	hi = &lo[size * (total_elems - 1)];
+	left = p_base + size;
+	right = hi;
+	pivot = p_base;
+	/* patition */
+	while(left <= right)
+	{
+		while (left < hi && cmp(left, pivot) < 0)
+			left += size;
+		while (right > lo && cmp(pivot, right) < 0)
+			right -= size;
+		if (left >= right)
+			break ;
+		swap(left, right, size);
+		left += size;
+		right -= size;
+	}
+	swap(right, pivot, size);
+	quick_sort(p_base, (right - p_base) / size, size, cmp);
+	quick_sort(right + size, (hi - right) / size, size, cmp);
+}

--- a/donghyuk/LeetCode/top_k_frequent/sort.h
+++ b/donghyuk/LeetCode/top_k_frequent/sort.h
@@ -1,0 +1,7 @@
+#ifndef SORT_H
+# define SORT_H
+# include <stdlib.h>
+
+void	quick_sort(void *base, size_t total_elems, size_t size, int (*cmp)(const void* left, const void* right));
+void	heap_sort();
+#endif

--- a/donghyuk/LeetCode/top_k_frequent/top_k_frequent_v1.c
+++ b/donghyuk/LeetCode/top_k_frequent/top_k_frequent_v1.c
@@ -1,0 +1,86 @@
+/*
+ * Author   : donghyuk
+ * Date     : 2022.04.17
+ * leetcode : https://leetcode.com/problems/top-k-frequent-elements
+ * Purpose  : Given an integer array nums and an integer k, return the k most frequent elements.
+ *
+ * How to Solve?
+ * 0. 이 버전은 퀵정렬만을 사용하여 문제를 해결했다. (해시 테이블,큐,힙 문제인줄 모르고...)
+ * 1. 배열의 값들을 카운트하여 저장한다.
+ *    - 값들을 카운트 하기 전, 배열을 정렬한다. [1, 3, 4, 2, 4, 1, 2, 3, 4] -> [1, 1, 2, 2, 3, 3, 4, 4, 4]
+ *    - 정렬된 배열을 0인덱스부터 순차적으로 카운팅하여 배열(t_node)에 저장한다.
+ * 2. 저장한 배열(t_node)을 카운트 별로 정렬한다. (내림차순)
+ * 3. 정렬된 배열(t_node)의 k번째만큼 저장하여 반환한다.
+ */
+
+#include "sort.h"
+
+typedef struct s_node
+{
+	int	val;
+	int	count;
+}	t_node;
+
+int num_cmp(const void* a, const void* b)
+{
+	return ((*(int *)a) - (*(int *)b));
+}
+
+int list_cmp(const void* a, const void* b)
+{
+	return ((((t_node *)b)->count) - (((t_node *)a)->count));
+}
+
+void	count_nums(t_node *list, int *nums, int size)
+{
+	int	idx;
+	int	cur_idx;
+	int	cur_num;
+
+	idx = 0;
+	cur_idx = 0;
+	while (idx < size)
+	{
+		list[cur_idx].val = nums[idx];
+		while (idx < size && list[cur_idx].val == nums[idx])
+		{
+			list[cur_idx].count++;
+			idx++;
+		}
+		cur_idx++;
+	}
+}
+
+int	*get_frequent_elems(t_node *list, int k)
+{
+	int	*result;
+	int	idx;
+
+	result = (int *)malloc(sizeof(int) * k);
+	if (!result)
+		exit(1);
+	idx = 0;
+	while (idx < k)
+	{
+		result[idx] = list[idx].val;
+		idx++;
+	}
+	return (result);
+}
+
+int	*topKFrequent(int* nums, int size, int k, int* returnSize)
+{
+	t_node *list;
+	int	*result;
+
+    *returnSize = k;
+	list = (t_node*)calloc(size ,sizeof(t_node));
+	if (!list)
+		exit(1);
+	quick_sort(nums, size, sizeof(int), num_cmp);
+	count_nums(list, nums, size);
+	quick_sort(list, size, sizeof(t_node), list_cmp);
+	result = get_frequent_elems(list, k);
+	free(list);
+	return (result);
+}

--- a/donghyuk/LeetCode/top_k_frequent/top_k_frequent_v2.c
+++ b/donghyuk/LeetCode/top_k_frequent/top_k_frequent_v2.c
@@ -1,0 +1,128 @@
+/*
+ * Author   : donghyuk
+ * Date     : 2022.04.17
+ * leetcode : https://leetcode.com/problems/top-k-frequent-elements
+ * Purpose  : Given an integer array nums and an integer k, return the k most frequent elements.
+ *
+ * How to Solve?
+ * - 아래 노션 참고
+ * - https://graceful-atom-bb0.notion.site/Sort-d32392b7d2e64c799c4ae3317a06bfb1
+ * */
+#include <stdlib.h>
+#include "sort.h"
+
+typedef struct s_node
+{
+	int	val;
+	int count;
+}	t_node;
+
+int list_cmp(const void* a, const void* b)
+{
+	return ((((t_node *)b)->count) - (((t_node *)a)->count));
+}
+
+/*
+ * size보다 작은 수의 소수를 구한다.
+ * 소수는 size에서 값을 1씩 빼면서 소수인지 아닌지 확인한다.
+ * */
+int getPrime(int size)
+{
+	int prime;
+	int i;
+
+	if (size < 2)
+		return (1);
+	prime = size;
+	i = 2;
+	while (i * i <= prime)
+	{
+		if (prime % i == 0)
+		{
+			i = 2;
+			prime--;
+			continue ;
+		}
+		break ;
+	}
+	return (prime);
+}
+
+/* 이중해싱을 통한 해시테이블 초기화
+ * 1차 해싱
+ *	사이즈 크기를 통한 나머지 연산을 통해 해시값(first_hash)을 구한다.
+ * 충돌 시,
+ *	2차 해싱을 통해 탐사 이동폭(step)을 구한다.
+ *		step = prime - (prev_hash mod prime) (prev_hash = 이전 해시값)
+ *		hash = first_hash + (idx2 * step)
+ *	2차 해싱 후 또 충돌이 일어날 시
+ *		idx2를 1증가 후 다시 2차 해싱을 시도한다.
+ *		다음 빈 공간을 찾을 때까지 계속 반복한다.
+ * */
+t_node	*init_table(int *nums, int size, int prime)
+{
+	t_node	*table;
+	int		idx;
+	int		idx2;
+	int		hash;
+	int		temp;
+
+	table = (t_node *)calloc(size, sizeof(t_node));
+	if (!table)
+		return (table);
+	idx = 0;
+	while (idx < size)
+	{
+		// 1차 해싱
+		hash = nums[idx] % size;
+		hash = (hash > 0) ? hash : -hash;
+		if (table[hash].count != 0 && table[hash].val != nums[idx])
+		{
+			// 충돌 시 2차 해싱
+			temp = hash;
+			hash = prime - (hash % prime);
+			idx2 = 1;
+			hash = (temp + (idx2 * hash)) % size;
+			while (table[hash].count != 0 && table[hash].val != nums[idx])
+			{
+				idx2++;
+				hash = prime - (hash % prime);
+				hash = (temp + (idx2 * hash)) % size;
+			}
+		}
+		table[hash].val = nums[idx++];
+		table[hash].count++;
+	}
+	return (table);
+}
+
+// 정렬된 테이블에서 k번째만큼 배열을 반환
+int	*get_frequent_elems(t_node *table, int k)
+{
+	int	*result;
+	int	idx;
+
+	result = (int *)malloc(sizeof(int) * k);
+	if (!result)
+		exit(1);
+	idx = 0;
+	while (idx < k)
+	{
+		result[idx] = table[idx].val;
+		idx++;
+	}
+	return (result);
+}
+
+int	*topKFrequent(int* nums, int size, int k, int* returnSize)
+{
+	t_node	*table;
+	int		*result;
+
+	*returnSize = k;
+	table = init_table(nums, size, getPrime(size));
+	quick_sort(table, size, sizeof(t_node), list_cmp);
+	result = get_frequent_elems(table, k);
+	free(table);
+	return (result);
+}


### PR DESCRIPTION
> top_k_frequent_v1
- 퀵정렬만 사용하여 문제 해결
> top_k_frequent_v2
- 해시테이블과 퀵정렬을 사용하여 문제 해결
- 해시테이블의 충돌처리방식에서 선형 탐사법과 이중 해시법을 구현해 비교해 보았다. (본 소스코드는 이중해시만 업로드)
- 선형 탐사법은 충돌 발생 시 다음 인덱스(hash + 1)에 저장하는 방식이다. 탐사 이동폭이 1로 고정되어있다.
- 이중 해시법은 충돌 발생 시 2차 해싱을 통해 다음 인덱스에 저장하는 방식이다. 탐사 이동폭이 hash2(k)로 유동적이다.
- 둘 방식의 실행 결과에 대한 차이는 놀라웠다. 결과는 노션의 top_k_frequent > 코드에 비교 이미지를 올려놓았다.
- https://graceful-atom-bb0.notion.site/Sort-d32392b7d2e64c799c4ae3317a06bfb1 